### PR TITLE
Changing a NBSP character to an actual space - found by random mistake

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ AcceptLanguage.prototype.languages = function(languageTags) {
     if(!this_.languageTags_[language]) {
       this_.languageTags_[language] = {
         values: region ? [languageTagString] : [],
-        regions: region ? [region] : [],
+        regions: region ? [region] : [],
         onlyLanguageValue: null
       };
     }


### PR DESCRIPTION
After inadvertently including this module in JavaScript sent to the browser, I saw that there was a character code 160 (NBSP) at this position--the browser barfed on it.

This is the only character 160 in the file; I've replaced it with a regular space (character 32).