### PR TITLE
Issue 12

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,18 +7,6 @@ var bcp47 = require('bcp47');
 
 
 /**
- * Object's size
- */
-Object.size = function(object) {
-  var size = 0, key;
-  for (key in object) {
-    if (object.hasOwnProperty(key)) size++;
-  }
-  return size;
-};
-
-
-/**
  * AcceptLanguage
  */
 var AcceptLanguage = function() {};
@@ -51,7 +39,7 @@ AcceptLanguage.prototype.defaultLanguageTag = null;
 AcceptLanguage.prototype.prune_ = function(languageTags) {
   var this_ = this;
 
-  if(Object.size(this.languageTags_) > 0) {
+  if(Object.keys(this.languageTags_).length > 0) {
     languageTags = languageTags
       .filter(function(languageTag) {
         var language = languageTag.language;

--- a/index.js
+++ b/index.js
@@ -9,10 +9,24 @@ var bcp47 = require('bcp47');
 /**
  * AcceptLanguage
  */
-function AcceptLanguage() {
-    this.languageTags_ = {};
-    this.defaultLanguageTag = null;
-}
+function AcceptLanguage() {}
+
+
+/**
+ * Language tags
+ *
+ * @type {Objects}
+ * @public
+ */
+AcceptLanguage.prototype.languageTags_ = {};
+
+
+/**
+ * Default language tag
+ *
+ * @type {String}
+ */
+AcceptLanguage.prototype.defaultLanguageTag = null;
 
 
 /**
@@ -116,6 +130,9 @@ AcceptLanguage.prototype.languages = function(languageTags) {
       throw new TypeError('Your language tag (' + languageTagString + ') are not bcp47 compliant. For more info https://tools.ietf.org/html/bcp47.');
     }
     var language = languageTag.langtag.language.language;
+    if(!language) {
+      throw new TypeError('Your language tag (' + languageTagString + ') is not supported.');
+    }
     var region = languageTag.langtag.region;
     if(!this_.languageTags_[language]) {
       this_.languageTags_[language] = {

--- a/index.js
+++ b/index.js
@@ -9,24 +9,10 @@ var bcp47 = require('bcp47');
 /**
  * AcceptLanguage
  */
-var AcceptLanguage = function() {};
-
-
-/**
- * Language tags
- *
- * @type {Objects}
- * @public
- */
-AcceptLanguage.prototype.languageTags_ = {};
-
-
-/**
- * Default language tag
- *
- * @type {String}
- */
-AcceptLanguage.prototype.defaultLanguageTag = null;
+function AcceptLanguage() {
+    this.languageTags_ = {};
+    this.defaultLanguageTag = null;
+}
 
 
 /**

--- a/index.js
+++ b/index.js
@@ -9,7 +9,9 @@ var bcp47 = require('bcp47');
 /**
  * AcceptLanguage
  */
-function AcceptLanguage() {}
+function AcceptLanguage() {
+  this.byLowerCaseTag = {};
+}
 
 
 /**
@@ -120,9 +122,11 @@ AcceptLanguage.prototype.prune_ = function(languageTags) {
  */
 AcceptLanguage.prototype.languages = function(languageTags) {
   var this_ = this;
+  var byLowerCaseTag = {};
 
   // Reset language tags
   this.languageTags_ = {};
+  this.byLowerCaseTag = byLowerCaseTag;
 
   languageTags.forEach(function(languageTagString) {
     var languageTag = bcp47.parse(languageTagString);
@@ -134,6 +138,7 @@ AcceptLanguage.prototype.languages = function(languageTags) {
       throw new TypeError('Your language tag (' + languageTagString + ') is not supported.');
     }
     var region = languageTag.langtag.region;
+    byLowerCaseTag[languageTagString.toLowerCase()] = languageTagString;
     if(!this_.languageTags_[language]) {
       this_.languageTags_[language] = {
         values: region ? [languageTagString] : [],
@@ -217,8 +222,84 @@ AcceptLanguage.prototype.get = function(string) {
   return this.parse(string)[0].value;
 };
 
+
 /**
- * For use as a single-ton
+ * Look up most suitable language tag according to BCP 47 rules, more precisely RFC 4647 "3.4. Lookup"
+ *
+ * @param {String} languagePriorityList Accept-Language header string
+ * @return {String}
+ * @public
+ */
+AcceptLanguage.prototype.lookup = function(languagePriorityList) {
+  if(typeof languagePriorityList !== 'string' || languagePriorityList.length === 0) {
+    return null;
+  }
+
+  var parsedAndSortedLanguageRanges = languagePriorityList.split(',').map(function(weightedLanguageRange) {
+    var components = weightedLanguageRange.replace(/\s+/, '').split(';');
+    return {
+      languageRange: components[0],
+      quality: components[1] ? parseFloat(components[1].split('=')[1]) : 1.0
+    };
+  })
+  // sort language ranges
+  .sort(function(a, b) {
+    return b.quality - a.quality;
+  });
+
+  // Array findIndex() would be more elegant, but it needs ECMAScript 2015
+  var i0, n0;
+  var languageRange; // term "language range" as used in RFC 4647
+  var prefixes;
+  var i1, n1;
+  var match;
+  for (i0=0, n0=parsedAndSortedLanguageRanges.length; i0<n0; i0++) {
+    languageRange = parsedAndSortedLanguageRanges[i0].languageRange;
+    if (match = this.byLowerCaseTag[languageRange.toLowerCase()]) {
+      return match;
+    }
+    prefixes = getPrefixes(languageRange);
+    for (i1=0, n1=prefixes.length; i1<n1; i1++) {
+      if (match = this.byLowerCaseTag[prefixes[i1]]) {
+        return match;
+      }
+    }
+  }
+  return null;
+
+  function getPrefixes(languageRange) {
+    var languageTag = bcp47.parse(languageRange);
+    if (!languageTag || !languageTag.langtag.language.language) { // langtag languages only
+      return [];
+    }
+    var langtag = languageTag.langtag;
+    var prefix = langtag.language.language.toLowerCase(); // the primary language is the shortest prefix
+    var prefixes = [prefix];
+    var delimiter = '-';
+    ['extlang', 'script', 'region', 'variant', 'extension', 'privateuse'].forEach(function(property) {
+      if (property === 'privateuse') {
+        delimiter = '-x-';
+      }
+      if (langtag[property] instanceof Array) {
+        langtag[property].forEach(check);
+      } else {
+        check(langtag[property]);
+      }
+
+      function check(subtag) {
+        if (subtag) {
+          prefix += delimiter + subtag.toLowerCase();
+          delimiter = '-';
+          prefixes.push(prefix);
+        }
+      }
+    });
+    return prefixes.reverse();
+  }
+};
+
+/**
+ * For use as a singleton
  */
 module.exports = new AcceptLanguage();
 

--- a/specifications/get.js
+++ b/specifications/get.js
@@ -1,0 +1,162 @@
+
+var AcceptLanguage = require('../').AcceptLanguage;
+
+module.exports = function(acceptLanguage) {
+  describe('get()', function() {
+    xit('should return no match on an empty language list', function() {
+      var acceptLanguage = new AcceptLanguage();
+      expect(acceptLanguage.get('en')).to.eql(null);
+    });
+
+    xit('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['en']);
+      expect(acceptLanguage.get('x-pirate')).to.eql(null);
+    });
+
+    it('should return matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['en']);
+      expect(acceptLanguage.get('en-US')).to.eql('en');
+    });
+
+    xit('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['en']);
+      expect(acceptLanguage.get('es')).to.eql(null);
+    });
+
+    xit('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh-Hans']);
+      expect(acceptLanguage.get('es')).to.eql(null);
+    });
+
+    xit('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['en', 'es-419', 'es-PO']);
+      expect(acceptLanguage.get('es-ES')).to.eql(null);
+    });
+
+    it('should return matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['es', 'es-419', 'es-PO']);
+      expect(acceptLanguage.get('es-ES')).to.eql('es');
+    });
+
+    xit('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh-Hant', 'zh-Hant-MO', 'zh-Hant-TW']);
+      expect(acceptLanguage.get('zh-CN')).to.eql(null);
+    });
+
+    it('should return exact match', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['es', 'es-419', 'es-PO']);
+      expect(acceptLanguage.get('es-419')).to.eql('es-419');
+    });
+
+    xit('should return exact match regardless of case', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['es', 'Es-419', 'es-PO']);
+      expect(acceptLanguage.get('eS-419')).to.eql('Es-419');
+    });
+
+    xit('should return matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh', 'zh-Hant-CN', 'zh-Hant-TW']);
+      expect(acceptLanguage.get('zh-TW')).to.eql('zh');
+    });
+
+    xit('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['en', 'es-419', 'es-PO']);
+      expect(acceptLanguage.get('es-ES, es-US;q=0.8')).to.eql(null);
+    });
+
+    xit('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh-Hant-TW']);
+      expect(acceptLanguage.get('es-ES')).to.eql(null);
+    });
+
+    xit('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh-Hant-TW', 'zh-Hans-CN']);
+      expect(acceptLanguage.get('zh-CN')).to.eql(null);
+    });
+
+    xit('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh-Hans-CN', 'zh-Hant-CN']);
+      expect(acceptLanguage.get('zh-CN')).to.eql(null);
+    });
+
+    it('should return the highest quality match', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['en-US', 'zh-CN']);
+      expect(acceptLanguage.get('en-US;q=0.8, zh-CN;q=1.0')).to.eql('zh-CN');
+    });
+
+    xit('should return the highest quality match', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['en', 'sr-Latn', 'sr-Cyrl']);
+      expect(acceptLanguage.get('en;q=0.8, sr-Cyrl-RS;q=1.0, sr-Latn-RS;q=0.95')).to.eql('sr-Cyrl');
+      expect(acceptLanguage.get('en;q=0.8, sr-Cyrl-RS;q=0.95, sr-Latn-BA;q=1.0')).to.eql('sr-Latn');
+      expect(acceptLanguage.get('en;q=0.8, sr-Cyrl;q=0.95, sr-Latn-ME;q=1.0')).to.eql('sr-Latn');
+      expect(acceptLanguage.get('en;q=0.8, sr-RS;q=1.0')).to.eql('en');
+      expect(acceptLanguage.get('en-US;q=0.8, sr-RS;q=1.0')).to.eql('en');
+      expect(acceptLanguage.get('en;q=0.8, sr-Latn;q=1.0')).to.eql('sr-Latn');
+      expect(acceptLanguage.get('en;q=0.8, sr-Latin;q=1.0')).to.eql('en'); // malformed script subtag
+      expect(acceptLanguage.get('en;q=0.8, sr-Lat;q=1.0')).to.eql('en'); // malformed script subtag
+      expect(acceptLanguage.get('en;q=0.8, sr;q=1.0')).to.eql('en');
+    });
+
+    xit('should return matches following an example given in RFC 4647', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh-Hant-CN-x-private1-private2']);
+      expect(acceptLanguage.get('en')).to.eql(null);
+      expect(acceptLanguage.get('zh-Hant-CN-x-private1-private2')).to.eql('zh-Hant-CN-x-private1-private2');
+      expect(acceptLanguage.get('zh-Hant-CN-x-private1')).to.eql(null);
+      expect(acceptLanguage.get('zh-Hant-CN')).to.eql(null);
+      expect(acceptLanguage.get('zh-Hant')).to.eql(null);
+      expect(acceptLanguage.get('zh')).to.eql(null);
+    });
+    xit('should return matches following an example given in RFC 4647', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh-Hant-CN']);
+      expect(acceptLanguage.get('en')).to.eql(null);
+      expect(acceptLanguage.get('zh-Hant-CN-x-private1-private2')).to.eql('zh-Hant-CN');
+      expect(acceptLanguage.get('zh-Hant-CN-x-private1')).to.eql('zh-Hant-CN');
+      expect(acceptLanguage.get('zh-Hant-CN')).to.eql('zh-Hant-CN');
+      expect(acceptLanguage.get('zh-Hant')).to.eql(null);
+      expect(acceptLanguage.get('zh')).to.eql(null);
+    });
+    xit('should return matches following an example given in RFC 4647', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh']);
+      expect(acceptLanguage.get('en')).to.eql(null);
+      expect(acceptLanguage.get('zh-Hant-CN-x-private1-private2')).to.eql('zh');
+      expect(acceptLanguage.get('zh-Hant-CN-x-private1')).to.eql('zh');
+      expect(acceptLanguage.get('zh-Hant-CN')).to.eql('zh');
+      expect(acceptLanguage.get('zh-Hant')).to.eql('zh');
+      expect(acceptLanguage.get('zh')).to.eql('zh');
+    });
+      
+    it('should return match following an example given in RFC 4647', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['de']);
+      expect(acceptLanguage.get('de-ch')).to.eql('de');
+    });
+    it('should return match following an example given in RFC 4647', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['de-CH']);
+      expect(acceptLanguage.get('de-ch')).to.eql('de-CH');
+    });
+    xit('should return no match following an example given in RFC 4647', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['de-CH-1966']);
+      expect(acceptLanguage.get('de-ch')).to.eql(null);
+    });
+  });
+};

--- a/specifications/index.js
+++ b/specifications/index.js
@@ -19,4 +19,6 @@ chai.use(sinonChai);
 describe('acceptLanguage', function() {
   require('./languages')(acceptLanguage);
   require('./parse')(acceptLanguage);
+  require('./get')(acceptLanguage);
+  require('./lookup')(acceptLanguage);
 });

--- a/specifications/languages.js
+++ b/specifications/languages.js
@@ -145,6 +145,20 @@ module.exports = function(acceptLanguage) {
         expect(method).to.throw('Your language tag (1) are not bcp47 compliant. For more info https://tools.ietf.org/html/bcp47.');
       });
 
+      it('should throw an error because the bcp47 does nut support wildcard subtags', function() {
+        var method = function() {
+          acceptLanguage.languages(['*-CH']); // (valid) example from RFC 4647
+        }
+        expect(method).to.throw('Your language tag (*-CH) are not bcp47 compliant. For more info https://tools.ietf.org/html/bcp47.');
+      });
+
+      it('should throw an error because the bcp47 does nut support wildcard subtags', function() {
+        var method = function() {
+          acceptLanguage.languages(['de-*-DE']); // (valid) example from RFC 4647
+        }
+        expect(method).to.throw('Your language tag (de-*-DE) are not bcp47 compliant. For more info https://tools.ietf.org/html/bcp47.');
+      });
+
       it('should throw an error if using incompliant language subtag', function() {
         var method = function() {
           acceptLanguage.languages(['e-US']);
@@ -164,6 +178,13 @@ module.exports = function(acceptLanguage) {
           acceptLanguage.languages(['zh-Ha-TW']);
         }
         expect(method).to.throw('Your language tag (zh-Ha-TW) are not bcp47 compliant. For more info https://tools.ietf.org/html/bcp47.');
+      });
+
+      it('should throw an error because private use tags are not supported', function() {
+        var method = function() {
+          acceptLanguage.languages(['x-pirate']);
+        }
+        expect(method).to.throw('Your language tag (x-pirate) is not supported.');
       });
     });
 

--- a/specifications/lookup.js
+++ b/specifications/lookup.js
@@ -1,0 +1,162 @@
+
+var AcceptLanguage = require('../').AcceptLanguage;
+
+module.exports = function(acceptLanguage) {
+  describe('lookup()', function() {
+    it('should return no match on an empty language list', function() {
+      var acceptLanguage = new AcceptLanguage();
+      expect(acceptLanguage.lookup('en')).to.eql(null);
+    });
+
+    it('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['en']);
+      expect(acceptLanguage.lookup('x-pirate')).to.eql(null);
+    });
+
+    it('should return matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['en']);
+      expect(acceptLanguage.lookup('en-US')).to.eql('en');
+    });
+
+    it('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['en']);
+      expect(acceptLanguage.lookup('es')).to.eql(null);
+    });
+
+    it('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh-Hans']);
+      expect(acceptLanguage.lookup('es')).to.eql(null);
+    });
+
+    it('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['en', 'es-419', 'es-PO']);
+      expect(acceptLanguage.lookup('es-ES')).to.eql(null);
+    });
+
+    it('should return matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['es', 'es-419', 'es-PO']);
+      expect(acceptLanguage.lookup('es-ES')).to.eql('es');
+    });
+
+    it('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh-Hant', 'zh-Hant-MO', 'zh-Hant-TW']);
+      expect(acceptLanguage.lookup('zh-CN')).to.eql(null);
+    });
+
+    it('should return exact match', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['es', 'es-419', 'es-PO']);
+      expect(acceptLanguage.lookup('es-419')).to.eql('es-419');
+    });
+
+    it('should return exact match regardless of case', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['es', 'Es-419', 'es-PO']);
+      expect(acceptLanguage.lookup('eS-419')).to.eql('Es-419');
+    });
+
+    it('should return matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh', 'zh-Hant-CN', 'zh-Hant-TW']);
+      expect(acceptLanguage.lookup('zh-TW')).to.eql('zh');
+    });
+
+    it('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['en', 'es-419', 'es-PO']);
+      expect(acceptLanguage.lookup('es-ES, es-US;q=0.8')).to.eql(null);
+    });
+
+    it('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh-Hant-TW']);
+      expect(acceptLanguage.lookup('es-ES')).to.eql(null);
+    });
+
+    it('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh-Hant-TW', 'zh-Hans-CN']);
+      expect(acceptLanguage.lookup('zh-CN')).to.eql(null);
+    });
+
+    it('should return no match when there is no matching prefix', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh-Hans-CN', 'zh-Hant-CN']);
+      expect(acceptLanguage.lookup('zh-CN')).to.eql(null);
+    });
+
+    it('should return the highest quality match', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['en-US', 'zh-CN']);
+      expect(acceptLanguage.lookup('en-US;q=0.8, zh-CN;q=1.0')).to.eql('zh-CN');
+    });
+
+    it('should return the highest quality match', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['en', 'sr-Latn', 'sr-Cyrl']);
+      expect(acceptLanguage.lookup('en;q=0.8, sr-Cyrl-RS;q=1.0, sr-Latn-RS;q=0.95')).to.eql('sr-Cyrl');
+      expect(acceptLanguage.lookup('en;q=0.8, sr-Cyrl-RS;q=0.95, sr-Latn-BA;q=1.0')).to.eql('sr-Latn');
+      expect(acceptLanguage.lookup('en;q=0.8, sr-Cyrl;q=0.95, sr-Latn-ME;q=1.0')).to.eql('sr-Latn');
+      expect(acceptLanguage.lookup('en;q=0.8, sr-RS;q=1.0')).to.eql('en');
+      expect(acceptLanguage.lookup('en-US;q=0.8, sr-RS;q=1.0')).to.eql('en');
+      expect(acceptLanguage.lookup('en;q=0.8, sr-Latn;q=1.0')).to.eql('sr-Latn');
+      expect(acceptLanguage.lookup('en;q=0.8, sr-Latin;q=1.0')).to.eql('en'); // malformed script subtag
+      expect(acceptLanguage.lookup('en;q=0.8, sr-Lat;q=1.0')).to.eql('en'); // malformed script subtag
+      expect(acceptLanguage.lookup('en;q=0.8, sr;q=1.0')).to.eql('en');
+    });
+
+    it('should return matches following an example given in RFC 4647', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh-Hant-CN-x-private1-private2']);
+      expect(acceptLanguage.lookup('en')).to.eql(null);
+      expect(acceptLanguage.lookup('zh-Hant-CN-x-private1-private2')).to.eql('zh-Hant-CN-x-private1-private2');
+      expect(acceptLanguage.lookup('zh-Hant-CN-x-private1')).to.eql(null);
+      expect(acceptLanguage.lookup('zh-Hant-CN')).to.eql(null);
+      expect(acceptLanguage.lookup('zh-Hant')).to.eql(null);
+      expect(acceptLanguage.lookup('zh')).to.eql(null);
+    });
+    it('should return matches following an example given in RFC 4647', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh-Hant-CN']);
+      expect(acceptLanguage.lookup('en')).to.eql(null);
+      expect(acceptLanguage.lookup('zh-Hant-CN-x-private1-private2')).to.eql('zh-Hant-CN');
+      expect(acceptLanguage.lookup('zh-Hant-CN-x-private1')).to.eql('zh-Hant-CN');
+      expect(acceptLanguage.lookup('zh-Hant-CN')).to.eql('zh-Hant-CN');
+      expect(acceptLanguage.lookup('zh-Hant')).to.eql(null);
+      expect(acceptLanguage.lookup('zh')).to.eql(null);
+    });
+    it('should return matches following an example given in RFC 4647', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['zh']);
+      expect(acceptLanguage.lookup('en')).to.eql(null);
+      expect(acceptLanguage.lookup('zh-Hant-CN-x-private1-private2')).to.eql('zh');
+      expect(acceptLanguage.lookup('zh-Hant-CN-x-private1')).to.eql('zh');
+      expect(acceptLanguage.lookup('zh-Hant-CN')).to.eql('zh');
+      expect(acceptLanguage.lookup('zh-Hant')).to.eql('zh');
+      expect(acceptLanguage.lookup('zh')).to.eql('zh');
+    });
+      
+    it('should return matches following an example given in RFC 4647', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['de']);
+      expect(acceptLanguage.lookup('de-ch')).to.eql('de');
+    });
+    it('should return matches following an example given in RFC 4647', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['de-CH']);
+      expect(acceptLanguage.lookup('de-ch')).to.eql('de-CH');
+    });
+    it('should return matches following an example given in RFC 4647', function() {
+      var acceptLanguage = new AcceptLanguage();
+      acceptLanguage.languages(['de-CH-1966']);
+      expect(acceptLanguage.lookup('de-ch')).to.eql(null);
+    });
+  });
+};

--- a/specifications/parse.js
+++ b/specifications/parse.js
@@ -178,12 +178,4 @@ module.exports = function(acceptLanguage) {
       }]);
     });
   });
-
-  describe('get()', function() {
-    it('should be able to get the first value', function() {
-      var acceptLanguage = new AcceptLanguage();
-      acceptLanguage.languages(['en-US', 'zh-CN']);
-      expect(acceptLanguage.get('en-US;q=0.8, zh-CN;q=1.0')).to.eql('zh-CN');
-    });
-  });
 };


### PR DESCRIPTION
I've implemented an additional `lookup` method that takes a different approach than your `get` based on your `parse`.

- instead of going through the full list of language ranges, it stops at the first match
- it implements the RFC 4647 matching rules (as far as I understand them)
- on the language tags side, it does not work based on the bcp47 parser results but uses trivial string lookup in an object
- it supports full langtag languages (limited to bcp47 module support)

Please bear with me, it's the first time I push to github and send a pull request...