### PR TITLE
Continue if no language could be found (supports *) fixes #17

### DIFF
--- a/Source/AcceptLanguage.ts
+++ b/Source/AcceptLanguage.ts
@@ -59,7 +59,13 @@ class AcceptLanguage {
         const result: string[] = [];
 
         for (const languageTag of parsedAndSortedLanguageTags) {
-            const requestedLangTag = bcp47.parse(languageTag.tag).langtag;
+            const requestedLang = bcp47.parse(languageTag.tag);
+
+            if (!requestedLang) {
+                continue;
+            }
+
+            const requestedLangTag = requestedLang.langtag;
 
             if (!this.languageTagsWithValues[requestedLangTag.language.language]) {
                 continue;

--- a/Tests/Test.ts
+++ b/Tests/Test.ts
@@ -88,6 +88,11 @@ describe('Language definitions', () => {
         expect(al.get('en-US;q=0.8,zh-Hant-CN-x-red;q=1')).to.equal('zh-Hant-CN-x-red');
     });
 
+    it('should match on *', () => {
+        const al = createInstance(['en-US']);
+        expect(al.get('*')).to.equal('en-US');
+    });
+
     it('should match subscripts based on priority', () => {
         const al = createInstance(['sv-SE', 'zh-Hant-CN-x-private1-private2']);
         expect(al.get('en-US;q=0.8,zh-Hant-CN-x-private1-private2;q=1')).to.equal('zh-Hant-CN-x-private1-private2');


### PR DESCRIPTION
See #17