### PR TITLE
Using a stable sort to keep order when equals

### DIFF
--- a/Source/AcceptLanguage.ts
+++ b/Source/AcceptLanguage.ts
@@ -1,5 +1,6 @@
 
 import bcp47 = require('bcp47');
+import stable = require('stable');
 
 interface LanguageTagWithValue extends bcp47.LanguageTag {
     value: string;
@@ -109,7 +110,7 @@ class AcceptLanguage {
         return result.length > 0 ? result : [this.defaultLanguageTag];
 
         function parseAndSortLanguageTags(languagePriorityList: string) {
-            return languagePriorityList.split(',').map((weightedLanguageRange) => {
+            return stable(languagePriorityList.split(',').map((weightedLanguageRange) => {
                 const components = weightedLanguageRange.replace(/\s+/, '').split(';');
                 return {
                     tag: components[0],
@@ -129,7 +130,7 @@ class AcceptLanguage {
             })
 
             // Sort by quality
-            .sort((a, b) => {
+            , (a, b) => {
                 return b.quality - a.quality;
             });
         }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/mocha": "^2.2.31"
   },
   "dependencies": {
-    "bcp47": "^1.1.2"
+    "bcp47": "^1.1.2",
+    "stable": "^0.1.6"
   }
 }


### PR DESCRIPTION
The sort method in not stable and doesn't always keep the original order of the list pass to it.
To fix that and to keep an order of priority (with equals values of `q`) I introduced `stable` as a dependency.

Extreme use case:
```js
var acceptLanguage = require("accept-language")
acceptLanguage.languages(['en', 'ja', 'ko', 'zh-CN', 'zh-TW', 'de', 'es', 'fr', 'it']);
var lang = acceptLanguage.get('en, ja, ne, zh, zh-TW, zh-CN, af, sq, am, ar, an');
// lang === 'zh-CN'
```