### PR TITLE
fix: remove deprecated dependency

### DIFF
--- a/Source/AcceptLanguage.ts
+++ b/Source/AcceptLanguage.ts
@@ -1,6 +1,5 @@
 
 import bcp47 = require('bcp47');
-import stable = require('stable');
 
 interface LanguageTagWithValue extends bcp47.LanguageTag {
     value: string;
@@ -174,7 +173,7 @@ class AcceptLanguage {
             }
         }
 
-        return result.length > 0 ? stable(result, (a, b) => {
+        return result.length > 0 ? result.sort((a, b) => {
             const quality = b.quality - a.quality;
             if (quality != 0) {
                 return quality;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "source-map-support": "^0.4.18"
   },
   "dependencies": {
-    "bcp47": "^1.1.2",
-    "stable": "^0.1.6"
+    "bcp47": "^1.1.2"
   }
 }


### PR DESCRIPTION
Removes the deprecated [`stable`](https://www.npmjs.com/package/stable) dependency and replaces it with [`Array.sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort).

Fixes the following warning message when installing the package:
<img width="1107" alt="image" src="https://github.com/user-attachments/assets/05ab1bf0-24b5-4a74-8a9d-2c3cc49c82aa">