### PR TITLE
fix: Use readonly type for languages array.

### DIFF
--- a/Library/Typings.d.ts
+++ b/Library/Typings.d.ts
@@ -6,7 +6,7 @@ declare module 'accept-language' {
         /**
          * Define your supported languages. The first language will be your default language.
          */
-        languages(languages: string[]): void;
+        languages(languages: readonly string[]): void;
 
         /**
          * Get matched language. If no match, the default language will be returned.

--- a/Library/Typings.d.ts
+++ b/Library/Typings.d.ts
@@ -6,7 +6,7 @@ declare module 'accept-language' {
         /**
          * Define your supported languages. The first language will be your default language.
          */
-        languages(languages: readonly string[]): void;
+        languages(languages: readonly [string, ...string[]]): void;
 
         /**
          * Get matched language. If no match, the default language will be returned.

--- a/Source/AcceptLanguage.ts
+++ b/Source/AcceptLanguage.ts
@@ -18,7 +18,7 @@ class AcceptLanguage {
 
     private defaultLanguageTag: string | null = null;
 
-    public languages(definedLanguages: string[]) {
+    public languages(definedLanguages: readonly [string, ...string[]]) {
         if (definedLanguages.length < 1) {
             throw new Error('No language tags defined. Provide at least 1 language tag to match.');
         }

--- a/Tests/Test.ts
+++ b/Tests/Test.ts
@@ -5,7 +5,7 @@ import AcceptLanguage from '../Source/AcceptLanguage';
 import chai = require('chai');
 const expect = chai.expect;
 
-function createInstance(definedLanguages?: string[]) {
+function createInstance(definedLanguages?: readonly [string, ...string[]]) {
     const al = AcceptLanguage.create();
     if (definedLanguages) {
         al.languages(definedLanguages);
@@ -16,7 +16,7 @@ function createInstance(definedLanguages?: string[]) {
 describe('Language definitions', () => {
     it('should throw when defined languages is empty', () => {
         const method = () => {
-            createInstance([]);
+            createInstance([] as any);
         };
         expect(method).to.throw();
     });


### PR DESCRIPTION
Defining the array argument as readonly allows setting the language array as const. 
Regular arrays are still allowed as `languages` param. The `readonly` is only applied to within the languages function.

Defining the language array as const makes typescript aware of the available languages.

Update: With the change from @MiroslavPetrik at least one language is enforced via the type system.

Fixes #40 